### PR TITLE
Split example code into folder, make it use installed lib not local build 

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
-for req in libtoolize autoreconf; do
-    if ! hash ${req}; then
-        echo "autogen.sh: error: cannot find program: ${req}"
-        exit 1
-    fi
-done
-
-for d in $(dirname $(readlink -f $0))/config $(dirname $(readlink -f $0))/m4; do
-    if ! mkdir -p $(dirname $(readlink -f $0))/config; then
-        echo "autogen.sh: error: cannot create directory: $d "
-        exit 1
-    fi
-done
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+    for req in autoreconf; do
+	if ! hash ${req}; then
+            echo "autogen.sh: error: cannot find program: ${req}"
+            exit 1
+	fi
+    done
+else
+    for req in libtoolize autoreconf; do
+	if ! hash ${req}; then
+            echo "autogen.sh: error: cannot find program: ${req}"
+            exit 1
+	fi
+    done
+    for d in $(dirname $(readlink -f $0))/config $(dirname $(readlink -f $0))/m4; do
+	if ! mkdir -p $(dirname $(readlink -f $0))/config; then
+            echo "autogen.sh: error: cannot create directory: $d "
+            exit 1
+	fi
+    done
+fi
 
 if ! autoreconf --install --force --verbose -I config; then
     echo "autogen.sh: error: cannot execute autoreconf"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 CC         = gcc
 CFLAGS     = -std=c99
 OUTFLAG    = -o
-LIBS       = -lusb-1.0 -lcrazyradio
+LIBS       = -lcrazyradio -lusb-1.0
 TARGET     = tx-test rx-test
 
 all:  $(TARGET)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,22 @@
+CC         = gcc
+CFLAGS     = -std=c99
+OUTFLAG    = -o
+LIBS       = -lusb-1.0 -lcrazyradio
+TARGET     = tx-test rx-test
+
+all:  $(TARGET)
+
+.c.o :
+	$(CC) $(CFLAGS) -c $<
+
+clean:
+	rm -f *.o *~ TAGS core $(TARGET)
+
+tags:
+	etags *.[ch] *.[ch]
+
+tx-test:
+	${CC} $(CFLAGS) -o $@ tx-test.c $(CF) $(INCLUDEDIR) $(LIBS)
+
+rx-test:
+	${CC} $(CFLAGS) -o $@ rx-test.c $(CF) $(INCLUDEDIR) $(LIBS)

--- a/examples/rx-test.c
+++ b/examples/rx-test.c
@@ -20,9 +20,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "crazyradio.h"
+#include <crazyradio.h>
 
-#include "config.h"
+#define VERSION "0.1"
 
 int main(int argc, char *argv[]) {
     cradio_device_t *dev;

--- a/examples/rx-test.c
+++ b/examples/rx-test.c
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+
 #include <crazyradio.h>
 
 #define VERSION "0.1"

--- a/examples/tx-test.c
+++ b/examples/tx-test.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
+#include <stdarg.h>
 #include <crazyradio.h>
 
 #define VERSION "0.1"

--- a/examples/tx-test.c
+++ b/examples/tx-test.c
@@ -23,9 +23,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "crazyradio.h"
+#include <crazyradio.h>
 
-#include "config.h"
+#define VERSION "0.1"
 
 int debug_level = 2;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,4 @@
 lib_LTLIBRARIES = libcrazyradio.la
-noinst_PROGRAMS = rx-test tx-test
 
 include_HEADERS = crazyradio.h
 
@@ -7,8 +6,3 @@ libcrazyradio_la_SOURCES = crazyradio.c crazyradio.h
 libcrazyradio_la_LIBS = @USB_LIBS@
 libcrazyradio_la_CFLAGS = @USB_CFLAGS@
 
-rx_test_SOURCES = rx-test.c
-tx_test_SOURCES = tx-test.c
-
-rx_test_LDADD = libcrazyradio.la @USB_LIBS@
-tx_test_LDADD = libcrazyradio.la @USB_LIBS@


### PR DESCRIPTION
- supports OSX
- moved test code into example folder and links to library not local build
- fixed build on linux